### PR TITLE
Fix lazy set!

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -1499,7 +1499,9 @@
      (syntax-case stx ()
        [(_ id expr)
         (if (identifier? #'id)
-            #'(set! id expr)
+          (with-syntax ([set! (if lazy? #'lazy:set! #'set!)])
+            (syntax/loc stx
+              (set! id expr)))
             (raise-syntax-error #f
                                 "expected an identifier"
                                 stx

--- a/tests/lazy.rkt
+++ b/tests/lazy.rkt
@@ -38,6 +38,19 @@
 
 ;; ----------------------------------------
 
+(test (let ([a 5] [f (lambda (x y) y)])
+        (f
+          (set! a 6)
+          a))
+      5)
+
+(test (let ([a 5])
+        (let ([b (set! a 6)])
+          (if (equal? (void) b) a -1)))
+      6)
+
+;; ----------------------------------------
+
 (define-type (MyList 'a)
   (my-empty)
   (my-cons [a : 'a]


### PR DESCRIPTION
Updated the `define-syntax` for `set!` to conditionally use the lazy-racket `set!` instead of always using the eager racket `set!`.

This pattern is already used for `define`, `if`, etc.

Also added a couple test cases to `tests` to verify this.