### PR TITLE
define-type form fix in definitions docs

### DIFF
--- a/scribblings/plait.scrbl
+++ b/scribblings/plait.scrbl
@@ -136,7 +136,7 @@ c]}
 
 @defform/subs[#:literals (: quote)
               (define-type tyid/abs
-                (variant-id [field-id : type])
+                (variant-id [field-id : type] ...)
                 ...)
               ([tyid/abs id
                          (id '@#,racket[_arg-id] ...)])]{


### PR DESCRIPTION
Added a `...` after `[field-id : type]` in the `define-type` form to indicate that a variant can have 0 or more fields